### PR TITLE
Disable Deer key-bindings by default

### DIFF
--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -37,8 +37,9 @@ zstyle ':prezto:load' pmodule \
 #
 # Deer
 #
+
 # Set key bindings
-zstyle ':prezto:module:deer' key-bindings '^k'
+# zstyle ':prezto:module:deer' key-bindings '^k'
 
 #
 # Autosuggestions


### PR DESCRIPTION
I think we should disable the key-bindings for `deer` by default or load the module by default.