### PR TITLE
[FIX] Enable SSH module for macOS Sierra

### DIFF
--- a/modules/ssh/README.md
+++ b/modules/ssh/README.md
@@ -3,9 +3,11 @@ SSH
 
 Provides for an easier use of [SSH][1] by setting up [ssh-agent][2].
 
-This module is disabled on Mac OS X due to custom Apple SSH support rendering it
-unnecessary. Use `ssh-add -K` to store identities in Keychain; they will be
-added to `ssh-agent` automatically and persist between reboots.
+This module is disabled on Mac OS X versions less than 10.12 (Sierra) due to
+custom Apple SSH support rendering it unnecessary. Use `ssh-add -K` to store
+identities in Keychain; they will be added to `ssh-agent` automatically and
+persist between reboots. This support was removed in macOS Sierra to [re-align
+behavior with mainstream OpenSSH](https://openradar.appspot.com/27348363).
 
 Settings
 --------

--- a/modules/ssh/init.zsh
+++ b/modules/ssh/init.zsh
@@ -6,7 +6,7 @@
 #
 
 # Return if requirements are not found.
-if [[ "$OSTYPE" == darwin* ]] || (( ! $+commands[ssh-agent] )); then
+if [[ `uname -s` == "Darwin" ]] && [[ `uname -r | awk -F. '{print $1}'` -le 15 ]] || (( ! $+commands[ssh-agent] )); then
   return 1
 fi
 


### PR DESCRIPTION
Due to a change in macOS Sierra (10.12), reenabling the SSH module for Sierra (and presumably later versions) is advantageous.