### PR TITLE
Refactor SSH Module

### DIFF
--- a/modules/ssh/README.md
+++ b/modules/ssh/README.md
@@ -3,12 +3,6 @@ SSH
 
 Provides for an easier use of [SSH][1] by setting up [ssh-agent][2].
 
-This module is disabled on Mac OS X versions less than 10.12 (Sierra) due to
-custom Apple SSH support rendering it unnecessary. Use `ssh-add -K` to store
-identities in Keychain; they will be added to `ssh-agent` automatically and
-persist between reboots. This support was removed in macOS Sierra to [re-align
-behavior with mainstream OpenSSH](https://openradar.appspot.com/27348363).
-
 Settings
 --------
 

--- a/modules/ssh/init.zsh
+++ b/modules/ssh/init.zsh
@@ -6,7 +6,7 @@
 #
 
 # Return if requirements are not found.
-if [[ `uname -s` == "Darwin" ]] && [[ `uname -r | awk -F. '{print $1}'` -le 15 ]] || (( ! $+commands[ssh-agent] )); then
+if (( ! $+commands[ssh-agent] )); then
   return 1
 fi
 
@@ -16,24 +16,11 @@ _ssh_dir="$HOME/.ssh"
 # Set the path to the environment file if not set by another module.
 _ssh_agent_env="${_ssh_agent_env:-${TMPDIR:-/tmp}/ssh-agent.env}"
 
-# Set the path to the persistent authentication socket.
-_ssh_agent_sock="${TMPDIR:-/tmp}/ssh-agent.sock"
-
 # Start ssh-agent if not started.
 if [[ ! -S "$SSH_AUTH_SOCK" ]]; then
   # Export environment variables.
   source "$_ssh_agent_env" 2> /dev/null
-
-  # Start ssh-agent if not started.
-  if ! ps -U "$LOGNAME" -o pid,ucomm | grep -q -- "${SSH_AGENT_PID:--1} ssh-agent"; then
-    eval "$(ssh-agent | sed '/^echo /d' | tee "$_ssh_agent_env")"
-  fi
-fi
-
-# Create a persistent SSH authentication socket.
-if [[ -S "$SSH_AUTH_SOCK" && "$SSH_AUTH_SOCK" != "$_ssh_agent_sock" ]]; then
-  ln -sf "$SSH_AUTH_SOCK" "$_ssh_agent_sock"
-  export SSH_AUTH_SOCK="$_ssh_agent_sock"
+  eval "$(ssh-agent -s)"
 fi
 
 # Load identities.
@@ -42,7 +29,12 @@ if ssh-add -l 2>&1 | grep -q 'The agent has no identities'; then
   if (( ${#_ssh_identities} > 0 )); then
     ssh-add "$_ssh_dir/${^_ssh_identities[@]}" 2> /dev/null
   else
-    ssh-add 2> /dev/null
+    # In macOS, `ssh-add -A` will load all identities defined in Keychain
+    if [[ `uname -s` == 'Darwin' ]]; then
+      ssh-add -A 2> /dev/null
+    else
+      ssh-add 2> /dev/null
+    fi
   fi
 fi
 


### PR DESCRIPTION
- Enabled the module for all macOS users.
- Removed creation of a persistent ssh-agent socket. At a minimum, this is
  unnecessary behavior. Its relative predictability could end up being a
  potential security issue on a multi-user system.
- Simplified ssh-agent startup and environment setup as a result.
- Enabled macOS-specific functionality to load identities stored in macOS
  Keychain. Behavior is a fallback if the user has not identified specific
  identities to be loaded in prezto configuration.

Created due to discussion/feedback in #5.