### PR TITLE
use non breaking space

### DIFF
--- a/modules/helper/init.zsh
+++ b/modules/helper/init.zsh
@@ -23,7 +23,7 @@ function is-true {
 
 # Prints the first non-empty string in the arguments array.
 function coalesce {
-  print "${${(s: :)@}[1]}"
+  print "${${(s:\u00A0:)@}[1]}"
 }
 
 


### PR DESCRIPTION
 fix race condition between what I assume is the Git completion, and the coalesce function, which, is used in prompt themes.