### PR TITLE
Add basic set of aliases for npm

### DIFF
--- a/modules/node/alias.zsh
+++ b/modules/node/alias.zsh
@@ -1,0 +1,4 @@
+alias ni="npm install"
+alias nig="npm install -g"
+alias nu="npm uninstall"
+alias nug="npm uninstall -g"

--- a/modules/node/init.zsh
+++ b/modules/node/init.zsh
@@ -62,3 +62,6 @@ if (( $+commands[npm] )); then
 
   unset cache_file
 fi
+
+# Source module files.
+source "${0:h}/alias.zsh"


### PR DESCRIPTION
The way aliases are loaded is adapted by the git module. Further aliases
can just be appended to the new `alias.zsh` file of this module.