### PR TITLE
Stop refreshing previous prompt

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -138,8 +138,8 @@ function zle-line-finish {
     echoti rmkx
   fi
 
-  # Update editor information.
-  zle editor-info
+  # Editor info is not updated as it causes unnecessary refresh in previous prompt.
+  # See discussion here: https://github.com/zsh-users/prezto/pull/17
 }
 zle -N zle-line-finish
 


### PR DESCRIPTION
This fixes https://github.com/sorin-ionescu/prezto/issues/667.

May be controversial, but I do think this is a bug, not a feature. There is no sense in treating the last prompt differently, and with the current behavior it is impossible to see when the last command started and how long it took to execute.

Before (pay attention to the time stamp on the right):
![before](https://cloud.githubusercontent.com/assets/1352887/4100838/f1cbe5fc-30b7-11e4-8ebb-87b4c24f06a8.png)

After:
![after](https://cloud.githubusercontent.com/assets/1352887/4100834/ca9b5274-30b7-11e4-8b0d-e8c3b354785c.png)