### PR TITLE
Indicate that `gbc` checks out to the created branch as well

### DIFF
--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -36,7 +36,7 @@ Aliases
 ### Branch
 
   - `gb` lists, creates, renames, and deletes branches.
-  - `gbc` creates a new branch.
+  - `gbc` creates and checks out a new branch.
   - `gbl` lists branches and their commits.
   - `gbL` lists local and remote branches and their commits.
   - `gbs` lists branches and their commits with ancestry graphs.


### PR DESCRIPTION
This PR improves the Readme of the `git` module to indicate that the `gbc` command checks out to the newly created branch.
