### PR TITLE
Add module 'encode64' from oh-my-zsh (renamed to 'base64')

### DIFF
--- a/modules/base64/README.md
+++ b/modules/base64/README.md
@@ -1,0 +1,13 @@
+base64
+=======
+
+Provides convenient aliases to encode and decode base64 strings.
+
+- `decode64` (alias: `d64`)
+- `encode64` (alias: `e64`)
+
+Credits
+-------
+
+- oh-my-zsh plugin [encode64](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/encode64/)
+

--- a/modules/base64/init.zsh
+++ b/modules/base64/init.zsh
@@ -1,0 +1,19 @@
+encode64() {
+  if [[ $# -eq 0 ]]; then
+    cat | base64
+  else
+    printf '%s' $1 | base64
+  fi
+}
+
+decode64() {
+  if [[ $# -eq 0 ]]; then
+    cat | base64 --decode
+  else
+    printf '%s' $1 | base64 --decode
+  fi
+}
+
+alias e64=encode64
+alias d64=decode64
+


### PR DESCRIPTION
A copy of another simple module called `encode64` from oh-my-zsh.
I renamed it to `base64` for convenience, because it provides decoding as well as encoding.