### PR TITLE
Don't load pfunctions from vi swap files

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -25,7 +25,7 @@ unset min_zsh_version
 function pmodload {
   local -a pmodules
   local pmodule
-  local pfunction_glob='^([_.]*|prompt_*_setup|README*)(-.N:t)'
+  local pfunction_glob='^([_.]*|prompt_*_setup|README*|*~)(-.N:t)'
 
   # $argv is overridden in the anonymous function.
   pmodules=("$argv[@]")


### PR DESCRIPTION
This modifies the pfunction regex so that it will not load functions from a vi backup files.

This prevents bad surprises in which functions from swap files are inadvertently loaded.