### PR TITLE
Revert "resolve race condition between git completion and coalesce function"

### DIFF
--- a/modules/helper/init.zsh
+++ b/modules/helper/init.zsh
@@ -23,7 +23,9 @@ function is-true {
 
 # Prints the first non-empty string in the arguments array.
 function coalesce {
-  print "${${(s: :)@}[1]}"
+  for arg in $argv; do
+    print "$arg"
+    return 0
+  done
+  return 1
 }
-
-


### PR DESCRIPTION
This reverts commit f7b981402d7e3fd04ab44fafe052f258cec8b950 which was proposed at sorin-ionescu/prezto#1241.

As reported in #23, this change treated any space as a new string.

cc @wonbyte @gmmeyer @johnpneumann 