### PR TITLE
Revert "Restore the parser status to PS2"

### DIFF
--- a/modules/editor/init.zsh
+++ b/modules/editor/init.zsh
@@ -124,9 +124,8 @@ function zle-line-init {
     echoti smkx
   fi
 
-  # https://github.com/zsh-users/prezto/issues/4
-  # Don't update editor info as it causes %_ (the parser status) not to be
-  # correctly rendered in prompts.
+  # Update editor information.
+  zle editor-info
 }
 zle -N zle-line-init
 


### PR DESCRIPTION
This reverts commit b2403a488091ae0d9c37c1005c56e695dc6b970c.

This change fixed the continuation prompt (#4), but broke something more important, the editor mode indicators (#48).

Not a permanent fix, but should give us a chance to decide what's best. Reverting this right away should prevent most users from noticing the problem.