### PR TITLE
Allow setting ZPREZTODIR to make prezto easier to integrate with

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -86,8 +86,11 @@ function pmodload {
 # Prezto Initialization
 #
 
-# Find the dir Prezto is installed to
-ZPREZTODIR=${ZPREZTODIR:-${ZDOTDIR:-$HOME}/.zprezto}
+# This finds the directory prezto is installed to so plugin managers don't need
+# to rely on dirty hacks to force prezto into a directory. Additionally, it
+# needs to be done here because inside the pmodload function ${0:h} evaluates to
+# the current directory of the shell rather than the prezto dir.
+ZPREZTODIR=${0:h}
 
 # Source the Prezto configuration file.
 if [[ -s "${ZDOTDIR:-$HOME}/.zpreztorc" ]]; then

--- a/init.zsh
+++ b/init.zsh
@@ -31,7 +31,7 @@ function pmodload {
   pmodules=("$argv[@]")
 
   # Add functions to $fpath.
-  fpath=(${pmodules:+${ZDOTDIR:-$HOME}/.zprezto/modules/${^pmodules}/functions(/FN)} $fpath)
+  fpath=(${pmodules:+$ZPREZTODIR/modules/${^pmodules}/functions(/FN)} $fpath)
 
   function {
     local pfunction
@@ -40,7 +40,7 @@ function pmodload {
     setopt LOCAL_OPTIONS EXTENDED_GLOB
 
     # Load Prezto functions.
-    for pfunction in ${ZDOTDIR:-$HOME}/.zprezto/modules/${^pmodules}/functions/$~pfunction_glob; do
+    for pfunction in $ZPREZTODIR/modules/${^pmodules}/functions/$~pfunction_glob; do
       autoload -Uz "$pfunction"
     done
   }
@@ -49,19 +49,19 @@ function pmodload {
   for pmodule in "$pmodules[@]"; do
     if zstyle -t ":prezto:module:$pmodule" loaded 'yes' 'no'; then
       continue
-    elif [[ ! -d "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule" ]]; then
+    elif [[ ! -d "$ZPREZTODIR/modules/$pmodule" ]]; then
       print "$0: no such module: $pmodule" >&2
       continue
     else
-      if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/init.zsh" ]]; then
-        source "${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/init.zsh"
+      if [[ -s "$ZPREZTODIR/modules/$pmodule/init.zsh" ]]; then
+        source "$ZPREZTODIR/modules/$pmodule/init.zsh"
       fi
 
       if (( $? == 0 )); then
         zstyle ":prezto:module:$pmodule" loaded 'yes'
       else
         # Remove the $fpath entry.
-        fpath[(r)${ZDOTDIR:-$HOME}/.zprezto/modules/${pmodule}/functions]=()
+        fpath[(r)${ZPREZTODIR}/modules/${pmodule}/functions]=()
 
         function {
           local pfunction
@@ -71,7 +71,7 @@ function pmodload {
           setopt LOCAL_OPTIONS EXTENDED_GLOB
 
           # Unload Prezto functions.
-          for pfunction in ${ZDOTDIR:-$HOME}/.zprezto/modules/$pmodule/functions/$~pfunction_glob; do
+          for pfunction in $ZPREZTODIR/modules/$pmodule/functions/$~pfunction_glob; do
             unfunction "$pfunction"
           done
         }
@@ -85,6 +85,9 @@ function pmodload {
 #
 # Prezto Initialization
 #
+
+# Find the dir Prezto is installed to
+ZPREZTODIR=${ZPREZTODIR:-${ZDOTDIR:-$HOME}/.zprezto}
 
 # Source the Prezto configuration file.
 if [[ -s "${ZDOTDIR:-$HOME}/.zpreztorc" ]]; then


### PR DESCRIPTION
This is arguably an annoying hack, but it lets the maintainers of antigen remove a bunch of weirdness which makes sure zprezto is in a folder named .zprezto and changing the ZDOTDIR at runtime to make loading this possible.

Obviously the name of the variable can be changed to whatever.