### PR TITLE
Add support for iTerm2 version 3

### DIFF
--- a/modules/osx/functions/tab
+++ b/modules/osx/functions/tab
@@ -39,3 +39,14 @@ EOF
     end tell
 EOF
 }
+
+[[ "$the_app" == 'iTerm2' ]] && {
+  osascript 2>/dev/null <<EOF
+    tell application "iTerm2"
+      tell current window
+        create tab with default profile
+        tell current session to write text "${command}"
+      end tell
+    end tell
+EOF
+}


### PR DESCRIPTION
iTerm 2 version 3.0 and up is registered as `iTerm2` rather than `iTerm`, and uses a different AppleScript API.

This provides support for using the `osx` module's `tab` command with new versions of iTerm 2.